### PR TITLE
feat: Phase 2 - データベース・ORM セットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Prisma generated client
+/generated
+
 # dependencies
 /node_modules
 /.pnp

--- a/TODO.md
+++ b/TODO.md
@@ -19,17 +19,17 @@
 
 ## Phase 2: データベース・ORM セットアップ
 
-- [ ] Prismaの初期化
+- [x] Prismaの初期化
   ```bash
   npx prisma init
   ```
-- [ ] `prisma/schema.prisma` にMongoDBスキーマを定義（Session / Message）
-- [ ] Prismaクライアントの生成
+- [x] `prisma/schema.prisma` にMongoDBスキーマを定義（Session / Message）
+- [x] Prismaクライアントの生成
   ```bash
   npx prisma generate
   ```
-- [ ] `lib/prisma.ts` にPrismaクライアントのシングルトンを実装
-- [ ] MongoDB接続の動作確認
+- [x] `lib/prisma.ts` にPrismaクライアントのシングルトンを実装
+- [ ] MongoDB接続の動作確認（DATABASE_URL設定後に実施）
 
 ---
 

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from "../generated/prisma";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mastra/core": "^0.24.9",
         "@prisma/client": "^7.5.0",
+        "dotenv": "^17.3.1",
         "hono": "^4.12.8",
         "next": "16.2.1",
         "prisma": "^7.5.0",
@@ -1750,6 +1751,18 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@mastra/core/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/@mastra/schema-compat": {
@@ -6028,6 +6041,18 @@
         }
       }
     },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -6550,9 +6575,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mastra/core": "^0.24.9",
     "@prisma/client": "^7.5.0",
+    "dotenv": "^17.3.1",
     "hono": "^4.12.8",
     "next": "16.2.1",
     "prisma": "^7.5.0",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,9 @@
+import "dotenv/config";
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  datasource: {
+    url: process.env.DATABASE_URL ?? "",
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,25 @@
+generator client {
+  provider = "prisma-client"
+  output   = "../generated/prisma"
+}
+
+datasource db {
+  provider = "mongodb"
+}
+
+model Session {
+  id        String    @id @default(auto()) @map("_id") @db.ObjectId
+  sessionId String    @unique
+  messages  Message[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}
+
+model Message {
+  id        String   @id @default(auto()) @map("_id") @db.ObjectId
+  sessionId String
+  session   Session  @relation(fields: [sessionId], references: [sessionId])
+  role      String
+  content   String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## 概要
Issue #2 Phase 2の実装完了。

## 変更内容

### 新規ファイル
- `prisma/schema.prisma` - MongoDB用スキーマ（Session / Messageモデル）
- `prisma.config.ts` - Prisma 7対応の設定ファイル
- `lib/prisma.ts` - PrismaClientシングルトン（Next.jsホットリロード対応）

### 変更ファイル
- `.gitignore` - `/generated` を追加（Prisma生成ファイルを除外）
- `package.json` - dotenvを追加

## Prisma 7 対応メモ
Prisma 7.xではスキーマの設定方法が変更されました：
- `schema.prisma` の `datasource` から `url` フィールドを削除
- 接続URLは `prisma.config.ts` で管理
- generatorのproviderが `prisma-client-js` → `prisma-client` に変更

## データモデル
```
Session: { id(ObjectId), sessionId(UUID, unique), messages[], createdAt, updatedAt }
Message: { id(ObjectId), sessionId, role, content, createdAt }
```

## 備考
MongoDB接続の動作確認はDATABASE_URLの設定が必要なため、環境構築後に実施。

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)