### PR TITLE
feat: Phase 7 - Dockerイメージ作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# 依存関係・ビルド成果物
+node_modules
+.next
+generated
+
+# 環境変数（機密情報）
+.env
+.env.*
+!.env.example
+
+# 開発・テスト用ファイル
+__tests__
+vitest.config.ts
+vitest.setup.ts
+*.test.ts
+*.test.tsx
+
+# Git・IDE
+.git
+.gitignore
+.vscode
+.idea
+
+# ドキュメント
+README.md
+AGENTS.md
+TODO.md
+
+# Docker自身
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# ---- deps stage ----
+FROM node:20-alpine AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY prisma ./prisma
+RUN npx prisma generate
+
+# ---- builder stage ----
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+COPY --from=deps /app/node_modules/.prisma ./node_modules/.prisma
+
+RUN npm run build
+
+# ---- runner stage ----
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static   ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public         ./public
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/TODO.md
+++ b/TODO.md
@@ -104,14 +104,15 @@
 
 ## Phase 7: Dockerイメージ作成
 
-- [ ] `Dockerfile` の作成（マルチステージビルド）
-- [ ] `.dockerignore` の作成
-- [ ] ローカルでのDockerビルド確認
+- [x] `Dockerfile` の作成（マルチステージビルド: deps / builder / runner）
+- [x] `.dockerignore` の作成
+- [x] `next.config.ts` に `output: "standalone"` を追加
+- [ ] ローカルでのDockerビルド確認（Docker Desktop起動後に実施）
   ```bash
   docker build -t ai-chat .
   docker run -p 3000:3000 --env-file .env.local ai-chat
   ```
-- [ ] Dockerコンテナ上での動作確認
+- [ ] Dockerコンテナ上での動作確認（同上）
 
 ---
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
 };
 
 export default nextConfig;


### PR DESCRIPTION
## 概要
Issue #7 Phase 7の実装完了。

## 変更内容

### 新規ファイル
**`Dockerfile`** — 3ステージマルチステージビルド

| ステージ | 内容 |
|---|---|
| `deps` | 本番依存のみ `npm ci --omit=dev` + `prisma generate` |
| `builder` | フルインストール + `npm run build`（standaloneビルド） |
| `runner` | `node:20-alpine` + 非rootユーザー `nextjs` で最小イメージ |

**`.dockerignore`** — ビルドコンテキストから除外
- `node_modules` / `.next` / `generated`
- `.env.*`（`.env.example` は含む）
- `__tests__` / `vitest.*` などテスト関連
- `.git` / `.vscode` など

### 変更ファイル
- `next.config.ts`: `output: "standalone"` 追加（Cloud Run向け最小サイズ化）

## 備考
Dockerデーモン未起動のためローカルビルド確認は Docker Desktop 起動後に手動実施してください：
```bash
docker build -t ai-chat .
docker run -p 3000:3000 --env-file .env.local ai-chat
```

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)