### PR TITLE
feat: Phase 8 - Google Cloud Runへのデプロイ設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: asia-northeast1
+  SERVICE: ai-chat
+  REGISTRY: asia-northeast1-docker.pkg.dev
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npm test
+
+  deploy:
+    name: Deploy
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Workload Identity Federation用
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Google Cloud認証（Workload Identity Federation推奨）
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
+
+      - name: Build and push Docker image
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}"
+          docker build -t "${IMAGE}:${{ github.sha }}" -t "${IMAGE}:latest" .
+          docker push --all-tags "${IMAGE}"
+
+      - name: Deploy to Cloud Run
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ github.sha }}"
+          gcloud run deploy ${{ env.SERVICE }} \
+            --image="${IMAGE}" \
+            --platform=managed \
+            --region=${{ env.REGION }} \
+            --allow-unauthenticated \
+            --min-instances=1 \
+            --max-instances=3 \
+            --concurrency=10 \
+            --memory=512Mi \
+            --cpu=1 \
+            --set-secrets="ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest"
+
+      - name: Show deployed URL
+        run: |
+          URL=$(gcloud run services describe ${{ env.SERVICE }} \
+            --platform=managed \
+            --region=${{ env.REGION }} \
+            --format='value(status.url)')
+          echo "✅ Deployed: ${URL}"

--- a/README.md
+++ b/README.md
@@ -1,36 +1,132 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# AI Chat
 
-## Getting Started
+Claudeを使ったエンターテイメント目的のAIチャットWebアプリケーション。
 
-First, run the development server:
+## 技術スタック
+
+- **フロントエンド/バックエンド**: Next.js 16 (App Router)
+- **APIレイヤー**: Hono
+- **AIエージェント**: Mastra + Claude (claude-sonnet-4-6)
+- **ORM**: Prisma 5
+- **データベース**: MongoDB
+- **デプロイ**: Google Cloud Run
+
+## ローカル開発
+
+### 前提条件
+
+- Node.js 20+
+- MongoDB (Atlas等)
+- Anthropic APIキー
+
+### セットアップ
 
 ```bash
+# 依存関係インストール
+npm install
+
+# 環境変数を設定
+cp .env.example .env.local
+# .env.local を編集して ANTHROPIC_API_KEY と DATABASE_URL を設定
+
+# Prismaクライアント生成
+npx prisma generate
+
+# 開発サーバー起動
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+ブラウザで [http://localhost:3000](http://localhost:3000) を開く。
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### テスト
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm test
+```
 
-## Learn More
+## Google Cloud Runへのデプロイ
 
-To learn more about Next.js, take a look at the following resources:
+### 事前準備
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+1. [Google Cloud Console](https://console.cloud.google.com) でプロジェクトを作成
+2. 必要なAPIを有効化：
+   ```bash
+   gcloud services enable run.googleapis.com \
+     cloudbuild.googleapis.com \
+     artifactregistry.googleapis.com \
+     secretmanager.googleapis.com
+   ```
+3. Secret Managerにシークレットを登録：
+   ```bash
+   echo -n "your-anthropic-api-key" | \
+     gcloud secrets create ANTHROPIC_API_KEY --data-file=-
+   echo -n "mongodb+srv://..." | \
+     gcloud secrets create DATABASE_URL --data-file=-
+   ```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+### 手動デプロイ
 
-## Deploy on Vercel
+```bash
+./scripts/deploy.sh <GCP_PROJECT_ID>
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### GitHub Actionsによる自動デプロイ
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+`main` ブランチへのプッシュで自動デプロイされます。
+
+以下のシークレットをGitHubリポジトリに設定してください：
+
+| シークレット名 | 内容 |
+|---|---|
+| `GCP_PROJECT_ID` | Google CloudプロジェクトID |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity ProviderのリソースID |
+| `GCP_SERVICE_ACCOUNT` | デプロイ用サービスアカウントのメール |
+
+#### Workload Identity Federation の設定
+
+```bash
+PROJECT_ID="your-project-id"
+SA_NAME="github-actions-deploy"
+
+# サービスアカウント作成
+gcloud iam service-accounts create ${SA_NAME} \
+  --display-name="GitHub Actions Deploy"
+
+# 必要な権限を付与
+for role in roles/run.admin roles/artifactregistry.writer roles/secretmanager.secretAccessor; do
+  gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role="${role}"
+done
+
+# Workload Identity Pool を作成
+gcloud iam workload-identity-pools create "github-pool" \
+  --location="global" \
+  --display-name="GitHub Actions Pool"
+
+# Provider を作成
+gcloud iam workload-identity-pools providers create-oidc "github-provider" \
+  --location="global" \
+  --workload-identity-pool="github-pool" \
+  --display-name="GitHub Provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+# バインディングを設定（自分のリポジトリに書き換える）
+REPO="your-github-username/ai-chat"
+gcloud iam service-accounts add-iam-policy-binding \
+  "${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')/locations/global/workloadIdentityPools/github-pool/attribute.repository/${REPO}"
+```
+
+## Cloud Run設定
+
+| 項目 | 値 |
+|---|---|
+| リージョン | asia-northeast1 (東京) |
+| 最小インスタンス数 | 1 |
+| 最大インスタンス数 | 3 |
+| 同時実行数 | 10 |
+| メモリ | 512Mi |
+| CPU | 1 |

--- a/TODO.md
+++ b/TODO.md
@@ -118,20 +118,19 @@
 
 ## Phase 8: Google Cloud Runへのデプロイ
 
-- [ ] Google Cloud プロジェクトの準備
-  - プロジェクトID確認
-  - Cloud Run API・Cloud Build APIの有効化
-- [ ] Container Registryへのイメージプッシュ
-  ```bash
-  gcloud builds submit --tag gcr.io/PROJECT_ID/ai-chat
-  ```
-- [ ] Cloud Runへのデプロイ
-  - リージョン: `asia-northeast1`
-  - 最小インスタンス: 1、最大インスタンス: 3
+- [x] Google Cloud プロジェクトの準備（手順をREADMEに記載）
+  - 必要API: Cloud Run / Cloud Build / Artifact Registry / Secret Manager
+  - Secret Managerへのシークレット登録手順を記載
+- [x] デプロイ設定ファイルの作成
+  - `cloudbuild.yaml`: Cloud Buildによる自動ビルド&デプロイ設定
+  - `.github/workflows/deploy.yml`: mainブランチpush時の自動デプロイ（Workload Identity Federation）
+  - `scripts/deploy.sh`: 手動デプロイスクリプト
+- [x] Cloud Runデプロイ設定
+  - リージョン: `asia-northeast1`、最小インスタンス: 1、最大インスタンス: 3
   - 同時実行数: 10、メモリ: 512Mi
-  - 環境変数の設定（ANTHROPIC_API_KEY, DATABASE_URL）
-- [ ] デプロイ後の動作確認（本番URL）
-- [ ] Cloud Runのログ確認
+  - 環境変数はSecret Manager経由で注入
+- [ ] デプロイ後の動作確認（GCPプロジェクト設定後に実施）
+- [ ] Cloud Runのログ確認（同上）
 
 ---
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,42 @@
+steps:
+  # 1. Dockerイメージをビルド
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      - build
+      - "-t"
+      - "asia-northeast1-docker.pkg.dev/$PROJECT_ID/ai-chat/ai-chat:$COMMIT_SHA"
+      - "-t"
+      - "asia-northeast1-docker.pkg.dev/$PROJECT_ID/ai-chat/ai-chat:latest"
+      - "."
+
+  # 2. Artifact Registryへプッシュ
+  - name: "gcr.io/cloud-builders/docker"
+    args:
+      - push
+      - "--all-tags"
+      - "asia-northeast1-docker.pkg.dev/$PROJECT_ID/ai-chat/ai-chat"
+
+  # 3. Cloud Runへデプロイ
+  - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ai-chat
+      - "--image=asia-northeast1-docker.pkg.dev/$PROJECT_ID/ai-chat/ai-chat:$COMMIT_SHA"
+      - "--platform=managed"
+      - "--region=asia-northeast1"
+      - "--allow-unauthenticated"
+      - "--min-instances=1"
+      - "--max-instances=3"
+      - "--concurrency=10"
+      - "--memory=512Mi"
+      - "--cpu=1"
+      - "--set-secrets=ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest"
+
+images:
+  - "asia-northeast1-docker.pkg.dev/$PROJECT_ID/ai-chat/ai-chat:$COMMIT_SHA"
+  - "asia-northeast1-docker.pkg.dev/$PROJECT_ID/ai-chat/ai-chat:latest"
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Cloud Runへの手動デプロイスクリプト
+# 使用方法: ./scripts/deploy.sh <GCP_PROJECT_ID>
+
+set -euo pipefail
+
+PROJECT_ID="${1:-}"
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "Error: GCP_PROJECT_IDを引数で指定してください"
+  echo "Usage: $0 <GCP_PROJECT_ID>"
+  exit 1
+fi
+
+REGION="asia-northeast1"
+SERVICE="ai-chat"
+REGISTRY="asia-northeast1-docker.pkg.dev"
+IMAGE="${REGISTRY}/${PROJECT_ID}/${SERVICE}/${SERVICE}"
+TAG=$(git rev-parse --short HEAD)
+
+echo "=== AI Chat デプロイ開始 ==="
+echo "Project: ${PROJECT_ID}"
+echo "Image:   ${IMAGE}:${TAG}"
+echo ""
+
+# 1. Artifact Registry リポジトリ作成（初回のみ）
+echo ">>> Artifact Registry リポジトリ確認..."
+gcloud artifacts repositories describe "${SERVICE}" \
+  --project="${PROJECT_ID}" \
+  --location="${REGION}" 2>/dev/null || \
+gcloud artifacts repositories create "${SERVICE}" \
+  --project="${PROJECT_ID}" \
+  --repository-format=docker \
+  --location="${REGION}" \
+  --description="AI Chat Docker images"
+
+# 2. Docker認証
+echo ">>> Docker認証..."
+gcloud auth configure-docker "${REGISTRY}" --quiet
+
+# 3. ビルド & プッシュ
+echo ">>> Dockerイメージをビルド中..."
+docker build -t "${IMAGE}:${TAG}" -t "${IMAGE}:latest" .
+
+echo ">>> Artifact Registryへプッシュ中..."
+docker push --all-tags "${IMAGE}"
+
+# 4. Cloud Runへデプロイ
+echo ">>> Cloud Runへデプロイ中..."
+gcloud run deploy "${SERVICE}" \
+  --project="${PROJECT_ID}" \
+  --image="${IMAGE}:${TAG}" \
+  --platform=managed \
+  --region="${REGION}" \
+  --allow-unauthenticated \
+  --min-instances=1 \
+  --max-instances=3 \
+  --concurrency=10 \
+  --memory=512Mi \
+  --cpu=1 \
+  --set-secrets="ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest"
+
+# 5. デプロイ結果を表示
+URL=$(gcloud run services describe "${SERVICE}" \
+  --project="${PROJECT_ID}" \
+  --platform=managed \
+  --region="${REGION}" \
+  --format='value(status.url)')
+
+echo ""
+echo "=== デプロイ完了 ==="
+echo "URL: ${URL}"


### PR DESCRIPTION
## 概要
Issue #8 Phase 8の実装完了。

## 変更内容

### 新規ファイル

**`cloudbuild.yaml`** — Cloud Buildトリガーによる自動デプロイ
- Artifact Registryへのイメージプッシュ（`COMMIT_SHA` タグ + `latest` タグ）
- `gcloud run deploy` でCloud Runへ自動デプロイ
- 環境変数はSecret Manager経由で注入（`--set-secrets`）

**`.github/workflows/deploy.yml`** — GitHub Actions CI/CDパイプライン

| ジョブ | 内容 |
|---|---|
| `test` | TypeScriptチェック + Vitestテスト実行 |
| `deploy` | Dockerビルド→Artifact Registry→Cloud Runデプロイ |

- **Workload Identity Federation**でサービスアカウントキー不要の認証
- `main` ブランチpush時にのみ発火

**`scripts/deploy.sh`** — 手動デプロイスクリプト
- Artifact Registryリポジトリ未存在時に自動作成
- `./scripts/deploy.sh <GCP_PROJECT_ID>` で実行

### 更新ファイル
- `README.md`: デプロイ手順・Workload Identity Federation設定コマンドを追記

## GitHubリポジトリに設定が必要なシークレット

| シークレット名 | 内容 |
|---|---|
| `GCP_PROJECT_ID` | Google CloudプロジェクトID |
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity ProviderリソースID |
| `GCP_SERVICE_ACCOUNT` | デプロイ用サービスアカウントのメール |

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)