### PR TITLE
feat: Vercelデプロイ対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,12 @@
-name: Deploy to Cloud Run
+name: Deploy to Vercel
 
 on:
   push:
     branches:
       - main
-
-env:
-  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  REGION: asia-northeast1
-  SERVICE: ai-chat
-  REGISTRY: asia-northeast1-docker.pkg.dev
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
@@ -27,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate Prisma Client
+        run: npx prisma generate
+
       - name: Type check
         run: npx tsc --noEmit
 
@@ -37,51 +37,15 @@ jobs:
     name: Deploy
     needs: test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write  # Workload Identity Federation用
-
+    # mainブランチへのpushのみデプロイ（PRはテストのみ）
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
 
-      # Google Cloud認証（Workload Identity Federation推奨）
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker for Artifact Registry
-        run: gcloud auth configure-docker ${{ env.REGISTRY }} --quiet
-
-      - name: Build and push Docker image
-        run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}"
-          docker build -t "${IMAGE}:${{ github.sha }}" -t "${IMAGE}:latest" .
-          docker push --all-tags "${IMAGE}"
-
-      - name: Deploy to Cloud Run
-        run: |
-          IMAGE="${{ env.REGISTRY }}/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ github.sha }}"
-          gcloud run deploy ${{ env.SERVICE }} \
-            --image="${IMAGE}" \
-            --platform=managed \
-            --region=${{ env.REGION }} \
-            --allow-unauthenticated \
-            --min-instances=1 \
-            --max-instances=3 \
-            --concurrency=10 \
-            --memory=512Mi \
-            --cpu=1 \
-            --set-secrets="ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest,DATABASE_URL=DATABASE_URL:latest"
-
-      - name: Show deployed URL
-        run: |
-          URL=$(gcloud run services describe ${{ env.SERVICE }} \
-            --platform=managed \
-            --region=${{ env.REGION }} \
-            --format='value(status.url)')
-          echo "✅ Deployed: ${URL}"
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: "--prod"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Claudeを使ったエンターテイメント目的のAIチャットWebアプリ
 - **AIエージェント**: Mastra + Claude (claude-sonnet-4-6)
 - **ORM**: Prisma 5
 - **データベース**: MongoDB
-- **デプロイ**: Google Cloud Run
+- **デプロイ**: Vercel
 
 ## ローカル開発
 
@@ -44,89 +44,60 @@ npm run dev
 npm test
 ```
 
-## Google Cloud Runへのデプロイ
+---
 
-### 事前準備
+## Vercelへのデプロイ（推奨・無料）
 
-1. [Google Cloud Console](https://console.cloud.google.com) でプロジェクトを作成
-2. 必要なAPIを有効化：
-   ```bash
-   gcloud services enable run.googleapis.com \
-     cloudbuild.googleapis.com \
-     artifactregistry.googleapis.com \
-     secretmanager.googleapis.com
-   ```
-3. Secret Managerにシークレットを登録：
-   ```bash
-   echo -n "your-anthropic-api-key" | \
-     gcloud secrets create ANTHROPIC_API_KEY --data-file=-
-   echo -n "mongodb+srv://..." | \
-     gcloud secrets create DATABASE_URL --data-file=-
-   ```
+### 方法A：GitHubと連携（最も簡単）
 
-### 手動デプロイ
+1. [vercel.com](https://vercel.com) にサインアップ / ログイン
+2. **Add New Project** → GitHubリポジトリ `ai-chat` を選択して **Import**
+3. **Environment Variables** に以下を入力：
+
+   | 変数名 | 値 |
+   |---|---|
+   | `ANTHROPIC_API_KEY` | `sk-ant-xxxx...` |
+   | `DATABASE_URL` | `mongodb+srv://...` |
+
+4. **Deploy** をクリック
+
+以降は `main` ブランチへのpushで自動デプロイされます。
+
+---
+
+### 方法B：Vercel CLI
+
+```bash
+# Vercel CLIをインストール
+npm i -g vercel
+
+# デプロイ（初回はブラウザで認証・プロジェクト設定）
+vercel
+
+# 本番環境へデプロイ
+vercel --prod
+```
+
+---
+
+### 方法C：GitHub Actionsによる自動デプロイ
+
+`main` ブランチへのpushでテスト→デプロイが自動実行されます。
+
+以下のシークレットをGitHubリポジトリの **Settings → Secrets and variables → Actions** に登録してください：
+
+| シークレット名 | 取得場所 |
+|---|---|
+| `VERCEL_TOKEN` | Vercel → Settings → Tokens |
+| `VERCEL_ORG_ID` | Vercel → Settings → General → Team ID |
+| `VERCEL_PROJECT_ID` | Vercel → Project → Settings → General → Project ID |
+
+---
+
+## Google Cloud Runへのデプロイ（代替）
+
+Cloud Runを使う場合は `scripts/deploy.sh` と `cloudbuild.yaml` を参照してください。
 
 ```bash
 ./scripts/deploy.sh <GCP_PROJECT_ID>
 ```
-
-### GitHub Actionsによる自動デプロイ
-
-`main` ブランチへのプッシュで自動デプロイされます。
-
-以下のシークレットをGitHubリポジトリに設定してください：
-
-| シークレット名 | 内容 |
-|---|---|
-| `GCP_PROJECT_ID` | Google CloudプロジェクトID |
-| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity ProviderのリソースID |
-| `GCP_SERVICE_ACCOUNT` | デプロイ用サービスアカウントのメール |
-
-#### Workload Identity Federation の設定
-
-```bash
-PROJECT_ID="your-project-id"
-SA_NAME="github-actions-deploy"
-
-# サービスアカウント作成
-gcloud iam service-accounts create ${SA_NAME} \
-  --display-name="GitHub Actions Deploy"
-
-# 必要な権限を付与
-for role in roles/run.admin roles/artifactregistry.writer roles/secretmanager.secretAccessor; do
-  gcloud projects add-iam-policy-binding ${PROJECT_ID} \
-    --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
-    --role="${role}"
-done
-
-# Workload Identity Pool を作成
-gcloud iam workload-identity-pools create "github-pool" \
-  --location="global" \
-  --display-name="GitHub Actions Pool"
-
-# Provider を作成
-gcloud iam workload-identity-pools providers create-oidc "github-provider" \
-  --location="global" \
-  --workload-identity-pool="github-pool" \
-  --display-name="GitHub Provider" \
-  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
-  --issuer-uri="https://token.actions.githubusercontent.com"
-
-# バインディングを設定（自分のリポジトリに書き換える）
-REPO="your-github-username/ai-chat"
-gcloud iam service-accounts add-iam-policy-binding \
-  "${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
-  --role="roles/iam.workloadIdentityUser" \
-  --member="principalSet://iam.googleapis.com/projects/$(gcloud projects describe ${PROJECT_ID} --format='value(projectNumber)')/locations/global/workloadIdentityPools/github-pool/attribute.repository/${REPO}"
-```
-
-## Cloud Run設定
-
-| 項目 | 値 |
-|---|---|
-| リージョン | asia-northeast1 (東京) |
-| 最小インスタンス数 | 1 |
-| 最大インスタンス数 | 3 |
-| 同時実行数 | 10 |
-| メモリ | 512Mi |
-| CPU | 1 |

--- a/app/api/[[...route]]/route.ts
+++ b/app/api/[[...route]]/route.ts
@@ -1,3 +1,5 @@
+export const runtime = "nodejs";
+
 import { Hono } from "hono";
 import { handle } from "hono/vercel";
 import { HTTPException } from "hono/http-exception";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  output: "standalone",
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## 概要
デプロイ先をVercel（無料・Hobbyプラン）に対応。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `next.config.ts` | `output: "standalone"` を削除（Vercel不要） |
| `app/api/[[...route]]/route.ts` | `export const runtime = "nodejs"` を追加（Prisma対応） |
| `.github/workflows/deploy.yml` | Vercel向けCI/CDに更新 |
| `README.md` | Vercelデプロイ手順を3方法で記載 |

## デプロイ方法（3種類）
1. **GitHubと連携**（最も簡単）— vercel.comでリポジトリをimportするだけ
2. **Vercel CLI** — `vercel --prod`
3. **GitHub Actions** — mainへのpushで自動デプロイ

## 確認
- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npm test` 26件全パス ✅

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)